### PR TITLE
feat: c-capnproto and capnp-janet musl-static packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,27 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: '11.0'
         TARGET_PLATFORM: ${{ matrix.target }}
+      name: Build c-capnproto-musl-static
+      run: pixi r build-ci c-capnproto-musl-static $TARGET_PLATFORM
+      shell: bash
+    - continue-on-error: true
+      env:
+        MACOSX_DEPLOYMENT_TARGET: '11.0'
+        TARGET_PLATFORM: ${{ matrix.target }}
+      name: Build capnp-janet
+      run: pixi r build-ci capnp-janet $TARGET_PLATFORM
+      shell: bash
+    - continue-on-error: true
+      env:
+        MACOSX_DEPLOYMENT_TARGET: '11.0'
+        TARGET_PLATFORM: ${{ matrix.target }}
+      name: Build capnp-janet-musl-static
+      run: pixi r build-ci capnp-janet-musl-static $TARGET_PLATFORM
+      shell: bash
+    - continue-on-error: true
+      env:
+        MACOSX_DEPLOYMENT_TARGET: '11.0'
+        TARGET_PLATFORM: ${{ matrix.target }}
       name: Build vesin
       run: pixi r build-ci vesin $TARGET_PLATFORM
       shell: bash

--- a/c-capnproto-musl-static/build.sh
+++ b/c-capnproto-musl-static/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Build libcapnp_c.a for x86_64-linux-musl via zig; install under $PREFIX/musl-static/.
+set -euo pipefail
+
+PREFIX="${PREFIX:?}"
+SRC="${SRC_DIR:-$PWD}"
+ZIG_TARGET="${ZIG_TARGET:-x86_64-linux-musl}"
+DEST="${PREFIX}/musl-static/c-capnproto"
+CPU_COUNT="${CPU_COUNT:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
+
+command -v zig >/dev/null
+command -v meson >/dev/null
+command -v ninja >/dev/null
+
+WRAP="$(mktemp -d)"
+trap 'rm -rf "$WRAP"' EXIT
+cat >"${WRAP}/zig-cc" <<EOF
+#!/bin/sh
+exec zig cc -target ${ZIG_TARGET} "\$@"
+EOF
+cat >"${WRAP}/zig-c++" <<EOF
+#!/bin/sh
+exec zig c++ -target ${ZIG_TARGET} "\$@"
+EOF
+cat >"${WRAP}/zig-ar" <<EOF
+#!/bin/sh
+exec zig ar "\$@"
+EOF
+chmod 755 "${WRAP}/zig-cc" "${WRAP}/zig-c++" "${WRAP}/zig-ar"
+
+export CC="${WRAP}/zig-cc"
+export CXX="${WRAP}/zig-c++"
+export AR="${WRAP}/zig-ar"
+export PATH="${WRAP}:${PATH}"
+
+BDIR="${SRC}/build-musl"
+rm -rf "$BDIR"
+meson setup "$BDIR" "$SRC" \
+  --prefix="$DEST" \
+  --libdir=lib \
+  --buildtype=release \
+  -Ddefault_library=static \
+  -Denable_tests=false \
+  --wrap-mode=nofallback
+
+meson compile -C "$BDIR" -j"${CPU_COUNT}"
+meson install -C "$BDIR"
+
+test -f "${DEST}/lib/libcapnp_c.a"
+test -f "${DEST}/include/capnp_c.h" || test -f "${DEST}/include/capnp/c/capn.h" || {
+  # header layout may vary; accept any capnp_c.h under include
+  find "${DEST}/include" -name 'capnp_c.h' | grep -q .
+}
+
+# Normalize pkg-config prefix for consumers that point PKG_CONFIG_PATH here.
+if [[ -f "${DEST}/lib/pkgconfig/c-capnproto.pc" ]]; then
+  sed -i.bak "s|^prefix=.*|prefix=${DEST}|" "${DEST}/lib/pkgconfig/c-capnproto.pc" 2>/dev/null \
+    || sed -i '' "s|^prefix=.*|prefix=${DEST}|" "${DEST}/lib/pkgconfig/c-capnproto.pc"
+  rm -f "${DEST}/lib/pkgconfig/c-capnproto.pc.bak"
+fi
+
+echo "ok: musl-static c-capnproto at ${DEST}"

--- a/c-capnproto-musl-static/recipe.yaml
+++ b/c-capnproto-musl-static/recipe.yaml
@@ -1,0 +1,57 @@
+# Static libcapnp_c.a for x86_64-linux-musl under $PREFIX/musl-static/c-capnproto/.
+# Host tools remain package `c-capnproto` (capnpc-c, shared/static host libs).
+context:
+  version: "0.1.0"
+  build_num: 0
+
+package:
+  name: c-capnproto-musl-static
+  version: ${{ version }}
+
+source:
+  url: https://github.com/HaoZeke/c-capnproto/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 23af5437aa6eaaf24a3f5b98380ab1e98e8613cc1912acc53704d1ab1185d208
+
+build:
+  number: ${{ build_num }}
+  string: h${{ hash }}_${{ build_num }}_musl
+  # Product musl is linux x86_64; zig can cross-build the .a on any host.
+  skip:
+    - win
+  script:
+    file: build.sh
+
+requirements:
+  build:
+    - zig
+    - meson
+    - ninja
+    - pkg-config
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - ${{ stdlib('c') }}
+  run:
+    - ${{ stdlib('c') }}
+
+tests:
+  - script:
+      - test -f $PREFIX/musl-static/c-capnproto/lib/libcapnp_c.a
+      - test -f $PREFIX/musl-static/c-capnproto/include/capnp_c.h
+      - test -f $PREFIX/musl-static/c-capnproto/lib/pkgconfig/c-capnproto.pc
+
+about:
+  homepage: https://github.com/HaoZeke/c-capnproto
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: "musl-static libcapnp_c.a (x86_64-linux-musl)"
+  description: |
+    Zig-built fully static Cap'n C runtime for x86_64-linux-musl linking.
+    Layout: $PREFIX/musl-static/c-capnproto/{lib,include}.
+    Does not replace host package `c-capnproto` (capnpc-c for schema compile).
+  repository: https://github.com/HaoZeke/c-capnproto
+
+extra:
+  recipe-maintainers:
+    - HaoZeke

--- a/c-capnproto-musl-static/variants.yaml
+++ b/c-capnproto-musl-static/variants.yaml
@@ -1,0 +1,1 @@
+# linux/osx build hosts; skip win in recipe. Output is always x86_64-linux-musl .a

--- a/capnp-janet-musl-static/build.sh
+++ b/capnp-janet-musl-static/build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX="${PREFIX:?}"
+SRC="${SRC_DIR:-$PWD}"
+ZIG_TARGET="${ZIG_TARGET:-x86_64-linux-musl}"
+DEST="${PREFIX}/musl-static/capnp-janet"
+CPU_COUNT="${CPU_COUNT:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
+
+command -v zig >/dev/null
+command -v meson >/dev/null
+
+WRAP="$(mktemp -d)"
+trap 'rm -rf "$WRAP"' EXIT
+cat >"${WRAP}/zig-cc" <<EOF
+#!/bin/sh
+exec zig cc -target ${ZIG_TARGET} "\$@"
+EOF
+cat >"${WRAP}/zig-c++" <<EOF
+#!/bin/sh
+exec zig c++ -target ${ZIG_TARGET} "\$@"
+EOF
+cat >"${WRAP}/zig-ar" <<EOF
+#!/bin/sh
+exec zig ar "\$@"
+EOF
+chmod 755 "${WRAP}/zig-cc" "${WRAP}/zig-c++" "${WRAP}/zig-ar"
+
+export CC="${WRAP}/zig-cc" CXX="${WRAP}/zig-c++" AR="${WRAP}/zig-ar"
+export PATH="${WRAP}:${PATH}"
+
+BDIR="${SRC}/build-musl"
+rm -rf "$BDIR"
+meson setup "$BDIR" "$SRC" \
+  --prefix="$DEST" \
+  --libdir=lib \
+  --buildtype=release \
+  -Ddefault_library=static \
+  --wrap-mode=nofallback
+meson compile -C "$BDIR" -j"${CPU_COUNT}"
+meson install -C "$BDIR"
+
+# library may land as libcapnp_janet.a
+test -f "${DEST}/lib/libcapnp_janet.a" \
+  || test -f "${DEST}/lib/libcapnp_janet.so" \
+  || find "${DEST}" -name 'libcapnp_janet.a' | grep -q .
+test -f "${DEST}/include/capnp-janet/capnp_message.h"
+echo "ok: musl-static capnp-janet at ${DEST}"

--- a/capnp-janet-musl-static/recipe.yaml
+++ b/capnp-janet-musl-static/recipe.yaml
@@ -1,0 +1,54 @@
+# Static libcapnp_janet.a for x86_64-linux-musl under $PREFIX/musl-static/capnp-janet/.
+context:
+  version: "0.2.0"
+  build_num: 0
+  git_rev: 9d8573be0bba1bc9bf7714b453fc3d1541aa785a
+
+package:
+  name: capnp-janet-musl-static
+  version: ${{ version }}
+
+source:
+  git: https://github.com/HaoZeke/capnp-janet.git
+  rev: ${{ git_rev }}
+
+build:
+  number: ${{ build_num }}
+  string: h${{ hash }}_${{ build_num }}_musl_gc_${{ git_rev[:7] }}
+  skip:
+    - win
+  script:
+    file: build.sh
+
+requirements:
+  build:
+    - zig
+    - meson
+    - ninja
+    - pkg-config
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - ${{ stdlib('c') }}
+  run:
+    - ${{ stdlib('c') }}
+
+tests:
+  - script:
+      - test -f $PREFIX/musl-static/capnp-janet/lib/libcapnp_janet.a
+      - test -f $PREFIX/musl-static/capnp-janet/include/capnp-janet/capnp_message.h
+
+about:
+  homepage: https://github.com/HaoZeke/capnp-janet
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "musl-static libcapnp_janet.a (x86_64-linux-musl)"
+  description: |
+    Zig-built static Cap'n Janet C runtime for x86_64-linux-musl linking.
+    Layout: $PREFIX/musl-static/capnp-janet/{lib,include}.
+  repository: https://github.com/HaoZeke/capnp-janet
+
+extra:
+  recipe-maintainers:
+    - HaoZeke

--- a/capnp-janet-musl-static/variants.yaml
+++ b/capnp-janet-musl-static/variants.yaml
@@ -1,0 +1,1 @@
+# linux/osx build hosts; output is x86_64-linux-musl static archive

--- a/capnp-janet/build.sh
+++ b/capnp-janet/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PREFIX="${PREFIX:?}"
+SRC="${SRC_DIR:-$PWD}"
+CPU_COUNT="${CPU_COUNT:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
+
+BDIR="${SRC}/build-host"
+rm -rf "$BDIR"
+meson setup "$BDIR" "$SRC" \
+  --prefix="$PREFIX" \
+  --libdir=lib \
+  --buildtype=release \
+  -Ddefault_library=both \
+  --wrap-mode=nofallback
+meson compile -C "$BDIR" -j"${CPU_COUNT}"
+meson install -C "$BDIR"
+test -f "${PREFIX}/include/capnp-janet/capnp_message.h"
+echo "ok: capnp-janet host install at ${PREFIX}"

--- a/capnp-janet/recipe.yaml
+++ b/capnp-janet/recipe.yaml
@@ -1,0 +1,55 @@
+# Host Cap'n C runtime used by Janet packs / embedders (public OSS).
+context:
+  version: "0.2.0"
+  build_num: 0
+  # 0.2.0-dev tip; pin by rev until a release tag exists.
+  git_rev: 9d8573be0bba1bc9bf7714b453fc3d1541aa785a
+
+package:
+  name: capnp-janet
+  version: ${{ version }}
+
+source:
+  git: https://github.com/HaoZeke/capnp-janet.git
+  rev: ${{ git_rev }}
+
+build:
+  number: ${{ build_num }}
+  string: h${{ hash }}_${{ build_num }}_gc_${{ git_rev[:7] }}
+  skip:
+    - win
+  script:
+    file: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+  host:
+    - ${{ stdlib('c') }}
+  run:
+    - ${{ stdlib('c') }}
+
+tests:
+  - script:
+      - test -f $PREFIX/include/capnp-janet/capnp_message.h
+      - test -e $PREFIX/lib/libcapnp_janet.a -o -e $PREFIX/lib/libcapnp_janet.so -o -e $PREFIX/lib/libcapnp_janet.dylib
+      - test -x $PREFIX/bin/capnpc-janet
+
+about:
+  homepage: https://github.com/HaoZeke/capnp-janet
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Cap'n Proto C runtime + Janet module (HaoZeke)"
+  description: |
+    Wire-format Cap'n C library and capnpc-janet plugin for embedders.
+    Host/shared build for tools; musl-static archives are package capnp-janet-musl-static.
+  repository: https://github.com/HaoZeke/capnp-janet
+
+extra:
+  recipe-maintainers:
+    - HaoZeke

--- a/capnp-janet/variants.yaml
+++ b/capnp-janet/variants.yaml
@@ -1,0 +1,1 @@
+# linux/osx; skip win in recipe

--- a/ci/gha/workflow.ncl
+++ b/ci/gha/workflow.ncl
@@ -67,6 +67,9 @@ ${{ runner.os }}-${{ matrix.target }}-rattler-pkgs-refs/heads/main-
           }
         },
         makeBuildStep "c-capnproto",
+        makeBuildStep "c-capnproto-musl-static",
+        makeBuildStep "capnp-janet",
+        makeBuildStep "capnp-janet-musl-static",
         makeBuildStep "vesin",
         makeBuildStep "ira",
         {

--- a/readme.org
+++ b/readme.org
@@ -1,5 +1,25 @@
 * About
-A forge containing packages not found elsewhere.
+A forge containing packages not found elsewhere (or not yet on conda-forge).
+
+Public channel: ~https://repo.prefix.dev/rg-forge~
+
+** Packages
+
+| Package | Role |
+|---------+------|
+| ~c-capnproto~ | Host Cap'n C runtime + ~capnpc-c~ |
+| ~c-capnproto-musl-static~ | Zig-built ~libcapnp_c.a~ for ~x86_64-linux-musl~ under ~$PREFIX/musl-static/c-capnproto/~ |
+| ~capnp-janet~ | Host Cap'n C library + Janet module + ~capnpc-janet~ |
+| ~capnp-janet-musl-static~ | Zig-built ~libcapnp_janet.a~ for ~x86_64-linux-musl~ under ~$PREFIX/musl-static/capnp-janet/~ |
+| ~ira~ | Iterative Rotations Assignments |
+| ~vesin~ | Neighbor lists (when not on conda-forge) |
+
+Host packages install into the normal conda prefix. ~*-musl-static~ packages install *only* under ~$PREFIX/musl-static/<name>/~ so they do not clash with host shared libs or ~capnpc-*~ tools.
+
+** Private channels
+
+prefix.dev supports private channels (API key / trusted publisher). Use a private channel for non-public artefacts; keep this public channel OSS-only. Auth: ~pixi auth prefix.dev --token …~ then ~rattler-build upload prefix -c <channel> …~.
+
 ** Background
 Much of the groundwork for this was written in the context of the ~mts-forge~ (now [[https://github.com/Luthaf/mts-forge][archived here]]). Eventually it was not found to be as viable for the Metatensor ecosystem as ~conda-forge~ integration. The basic concept still makes for a nice playground so it remains here.
 * License


### PR DESCRIPTION
## Summary

- `c-capnproto-musl-static`: zig-built `libcapnp_c.a` for `x86_64-linux-musl` under `$PREFIX/musl-static/c-capnproto/`
- `capnp-janet` + `capnp-janet-musl-static`: host package and musl-static archive under `$PREFIX/musl-static/capnp-janet/`
- GHA matrix builds the new recipes; host `c-capnproto` unchanged

Host tools stay on normal packages; musl-static layouts do not replace `capnpc-*`.

## Test plan

- [ ] GHA builds `c-capnproto-musl-static` and `capnp-janet*` on linux-64
- [ ] Installed layout: `$PREFIX/musl-static/*/lib/*.a` present
- [ ] Upload to `rg-forge` channel on push to main